### PR TITLE
ユーザーテーブルにニックネームカラムを追加

### DIFF
--- a/library-appli/app/controllers/users_controller.rb
+++ b/library-appli/app/controllers/users_controller.rb
@@ -11,4 +11,5 @@ class UsersController < ApplicationController
 	  # @image = item['smallImageUrl']
 	  # end
 	end
+
 end

--- a/library-appli/app/views/devise/registrations/new.html.erb
+++ b/library-appli/app/views/devise/registrations/new.html.erb
@@ -21,6 +21,9 @@
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
+  <div class="label"><%= f.label :nickname %><br />
+          <%= f.text_field :nickname %></div>
+
   <div class="actions">
     <%= f.submit "Sign up" %>
   </div>

--- a/library-appli/app/views/users/index.html.erb
+++ b/library-appli/app/views/users/index.html.erb
@@ -1,11 +1,5 @@
 <div class="test">
-	<% @items.each do |item| %>
-		<%=item['itemName']%>
-		<%=item['itemPrice']%>
-		<%=item['itemUrl']%>
-		<%=item['smallImageUrl']%>
-    <img src="<%=item['mediumImageUrls']%>"> 
-	<% end %>
+	
     
 </div>
 

--- a/library-appli/config/routes.rb
+++ b/library-appli/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
-  root 'users#index'
+  
   resources :users, only: [:show,:index] do
   	resources :posts
   end
-
+  root 'users#index'
 end

--- a/library-appli/db/migrate/20181220015847_add_nickname_to_users.rb
+++ b/library-appli/db/migrate/20181220015847_add_nickname_to_users.rb
@@ -1,0 +1,5 @@
+class AddNicknameToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :nickname, :string
+  end
+end

--- a/library-appli/db/schema.rb
+++ b/library-appli/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181219085949) do
+ActiveRecord::Schema.define(version: 20181220015847) do
 
   create_table "posts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.text     "quote",      limit: 65535, null: false
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20181219085949) do
     t.datetime "remember_created_at"
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
+    t.string   "nickname"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end


### PR DESCRIPTION
# WHAT
ユーザーテーブルにニックネームカラムを追加

# WHY
トップ画面表示に必要であるため。